### PR TITLE
Fix warnings about unused variables for warningless compilation

### DIFF
--- a/plugins/doip/packet-doip.c
+++ b/plugins/doip/packet-doip.c
@@ -177,6 +177,7 @@ static void dissect_doip_message(tvbuff_t *tvb, packet_info *pinfo, proto_tree *
 // determine PDU length of protocol DoIP
 static guint get_doip_message_len(packet_info *pinfo _U_, tvbuff_t *tvb, int offset, void *p)
 {
+    (void) p;
     const guint DOIP_HEADER_LEN = 8;
     return (guint)tvb_get_ntohl(tvb, offset+4) + DOIP_HEADER_LEN; // length is at offset 4 and is 4 bytes
 }

--- a/plugins/uds/packet-uds.c
+++ b/plugins/uds/packet-uds.c
@@ -124,6 +124,7 @@ gint add_header(proto_tree *uds_tree, tvbuff_t *tvb)
 /* Uds protocol dissector */
 static int dissect_uds_message(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void* data)
 {
+    (void) data;
     gint offset = 0;
     guint8 service = 0;
     proto_tree *uds_tree = NULL;

--- a/plugins/uds/request_download.c
+++ b/plugins/uds/request_download.c
@@ -24,6 +24,7 @@ static const value_string compression_encrypting[] = {
 
 gint add_request_download_fields(proto_tree *uds_tree, packet_info *pinfo, tvbuff_t *tvb, gint offset)
 {
+    (void) pinfo;
         //guint8 data_format = tvb_get_guint8(tvb, offset);
 	guint8 length_address_format = tvb_get_guint8(tvb, offset + 1);
 	guint8 length_lenght = (length_address_format & 0xF0) >> 4;
@@ -46,6 +47,7 @@ gint add_request_download_fields(proto_tree *uds_tree, packet_info *pinfo, tvbuf
 
 gint add_request_download_response_fields(proto_tree *uds_tree, packet_info *pinfo, tvbuff_t *tvb, gint offset)
 {
+    (void) pinfo;
 
         guint8 length_address_format = tvb_get_guint8(tvb, offset);
 	guint8 length_lenght = (length_address_format & 0xF0) >> 4;

--- a/plugins/uds/request_transfer_exit.c
+++ b/plugins/uds/request_transfer_exit.c
@@ -14,6 +14,7 @@ static int hf_parameters_response = -1;
 
 gint add_request_transfer_exit_fields(proto_tree *uds_tree, packet_info *pinfo, tvbuff_t *tvb, gint offset)
 {
+    (void) pinfo;
 	gint remaining = 0;
 
 	if (uds_tree)
@@ -31,6 +32,7 @@ gint add_request_transfer_exit_fields(proto_tree *uds_tree, packet_info *pinfo, 
 
 gint add_request_transfer_exit_response_fields(proto_tree *uds_tree, packet_info *pinfo, tvbuff_t *tvb, gint offset)
 {
+    (void) pinfo;
 	gint remaining = 0;
 
 	if (uds_tree)


### PR DESCRIPTION
Hi,

the plugins would'nt build with gcc 5.4 under Ubuntu 16.04 because of some  unused variables and the -werror flag used when building with CMake.